### PR TITLE
Make `database` a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ keywords    = ["address", "mac", "hw", "network"]
 phf = "0.7"
 
 [build-dependencies]
-reqwest     = "0.9"
-url         = "1.4"
-regex       = "1.0"
-phf_codegen = "0.7"
+reqwest     = {version = "0.9", optional = true}
+url         = {version = "1.4", optional = true}
+regex       = {version = "1.0", optional = true}
+phf_codegen = {version = "0.7", optional = true}
 
 [features]
-database = []
+database = ["reqwest", "url", "regex", "phf_codegen"]

--- a/build.rs
+++ b/build.rs
@@ -12,82 +12,94 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-extern crate reqwest;
-extern crate url;
-extern crate regex;
-extern crate phf_codegen;
-
-use std::env;
-use std::io::{Read, Write, BufWriter};
-use std::fs::File;
-use std::path::Path;
-use std::collections::HashSet;
-
-use url::Url;
-use regex::Regex;
-
 fn main() {
-	if env::var("CARGO_FEATURE_DATABASE").is_err() {
-		return;
-	}
+    database_impl::main_();
+}
 
-	let mut content = String::new();
+#[cfg(not(feature="database"))]
+mod database_impl {
+    pub fn main_() { }
+}
 
-	if let Ok(value) = env::var("HWADDR_DATABASE") {
-		File::open(value).unwrap().read_to_string(&mut content).unwrap();
-	}
-	else if let Ok(url) = env::var("HWADDR_DOWNLOAD") {
-		if Url::parse(&url).is_ok() {
-			reqwest::get(&url).unwrap()
-		}
-		else {
-			reqwest::get("http://standards.ieee.org/develop/regauth/oui/oui.txt").unwrap()
-		}.read_to_string(&mut content).unwrap();
-	}
-	else {
-		File::open("database.txt").unwrap().read_to_string(&mut content).unwrap();
-	}
+#[cfg(feature="database")]
+mod database_impl {
+    extern crate reqwest;
+    extern crate url;
+    extern crate regex;
+    extern crate phf_codegen;
 
-	let     path    = Path::new(&env::var("OUT_DIR").unwrap()).join("database.rs");
-	let mut file    = BufWriter::new(File::create(&path).unwrap());
-	let mut builder = phf_codegen::Map::new();
+    use std::env;
+    use std::io::{Read, Write, BufWriter};
+    use std::fs::File;
+    use std::path::Path;
+    use std::collections::HashSet;
 
-	write!(&mut file, "pub static DATABASE: ::phf::Map<[u8; 3], Producer> = ").unwrap();
+    use self::url::Url;
+    use self::regex::Regex;
 
-	let mut lines   = content.lines();
-	let mut entries = HashSet::new();
-	let     start   = Regex::new(r#"^(?P<prefix>[[:xdigit:]]{6})\s+\(base 16\)\s*(?P<name>.+)$"#).unwrap();
+    pub fn main_() {
+        if env::var("CARGO_FEATURE_DATABASE").is_err() {
+            return;
+        }
 
-	while let Some(line) = lines.next() {
-		if let Some(captures) = start.captures(line) {
-			let prefix = captures["prefix"].to_owned();
-			let prefix = [
-				u8::from_str_radix(&prefix[0 .. 2], 16).unwrap(),
-				u8::from_str_radix(&prefix[2 .. 4], 16).unwrap(),
-				u8::from_str_radix(&prefix[4 .. 6], 16).unwrap() ];
+        let mut content = String::new();
 
-			let name    = captures["name"].to_owned();
-			let street  = lines.next().unwrap().trim().to_owned();
-			let city    = lines.next().unwrap().trim().to_owned();
-			let country = lines.next().unwrap().trim().to_owned();
+        if let Ok(value) = env::var("HWADDR_DATABASE") {
+            File::open(value).unwrap().read_to_string(&mut content).unwrap();
+        }
+        else if let Ok(url) = env::var("HWADDR_DOWNLOAD") {
+            if Url::parse(&url).is_ok() {
+                reqwest::get(&url).unwrap()
+            }
+            else {
+                reqwest::get("http://standards.ieee.org/develop/regauth/oui/oui.txt").unwrap()
+            }.read_to_string(&mut content).unwrap();
+        }
+        else {
+            File::open("database.txt").unwrap().read_to_string(&mut content).unwrap();
+        }
 
-			if !entries.contains(&prefix) {
-				entries.insert(prefix);
-				builder.entry(prefix, &format!(r#"
-					Producer {{
-						prefix:  {:?},
-						name:    {:?},
-						address: Address {{
-							street:  {:?},
-							city:    {:?},
-							country: {:?},
-						}},
-					}}
-				"#, prefix, name, street, city, country));
-			}
-		}
-	}
+        let     path    = Path::new(&env::var("OUT_DIR").unwrap()).join("database.rs");
+        let mut file    = BufWriter::new(File::create(&path).unwrap());
+        let mut builder = phf_codegen::Map::new();
 
-	builder.build(&mut file).unwrap();
-	write!(&mut file, ";\n").unwrap();
+        write!(&mut file, "pub static DATABASE: ::phf::Map<[u8; 3], Producer> = ").unwrap();
+
+        let mut lines   = content.lines();
+        let mut entries = HashSet::new();
+        let     start   = Regex::new(r#"^(?P<prefix>[[:xdigit:]]{6})\s+\(base 16\)\s*(?P<name>.+)$"#).unwrap();
+
+        while let Some(line) = lines.next() {
+            if let Some(captures) = start.captures(line) {
+                let prefix = captures["prefix"].to_owned();
+                let prefix = [
+                    u8::from_str_radix(&prefix[0 .. 2], 16).unwrap(),
+                    u8::from_str_radix(&prefix[2 .. 4], 16).unwrap(),
+                    u8::from_str_radix(&prefix[4 .. 6], 16).unwrap() ];
+
+                let name    = captures["name"].to_owned();
+                let street  = lines.next().unwrap().trim().to_owned();
+                let city    = lines.next().unwrap().trim().to_owned();
+                let country = lines.next().unwrap().trim().to_owned();
+
+                if !entries.contains(&prefix) {
+                    entries.insert(prefix);
+                    builder.entry(prefix, &format!(r#"
+                        Producer {{
+                            prefix:  {:?},
+                            name:    {:?},
+                            address: Address {{
+                                street:  {:?},
+                                city:    {:?},
+                                country: {:?},
+                            }},
+                        }}
+                    "#, prefix, name, street, city, country));
+                }
+            }
+        }
+
+        builder.build(&mut file).unwrap();
+        write!(&mut file, ";\n").unwrap();
+    }
 }


### PR DESCRIPTION
Avoids cargo pulling in and compiling the `reqwest`, `url`, `regex`, `phf_codegen`
unless requested by adding the database feature.