### PR TITLE
fix: make phf an optional dependency if the database is not in use, fix build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository  = "https://github.com/meh/rust-hwaddr"
 keywords    = ["address", "mac", "hw", "network"]
 
 [dependencies]
-phf = "0.8"
+phf = { version = "0.8", optional = true }
 
 [build-dependencies]
 smol        = { version = "1.0", optional = true }
@@ -21,4 +21,4 @@ regex       = { version = "1", optional = true }
 phf_codegen = { version = "0.8", optional = true }
 
 [features]
-database = ["smol", "reqwest", "url", "regex", "phf_codegen"]
+database = ["smol", "reqwest", "url", "regex", "phf", "phf_codegen"]

--- a/build.rs
+++ b/build.rs
@@ -14,11 +14,11 @@
 
 use std::env;
 
-#[cfg(features = "database")]
+#[cfg(feature = "database")]
 use std::{io::{Read, Write, BufWriter}, fs::File, path::Path, collections::HashSet};
-#[cfg(features = "database")]
+#[cfg(feature = "database")]
 use url::Url;
-#[cfg(features = "database")]
+#[cfg(feature = "database")]
 use regex::Regex;
 
 fn main() {
@@ -26,7 +26,7 @@ fn main() {
 		return;
 	}
 
-	#[cfg(features = "database")]
+	#[cfg(feature = "database")]
 	smol::block_on(async {
 		let mut content = String::new();
 


### PR DESCRIPTION
This cuts out `phf`, `phf_shared`, and `siphasher` from the default build.